### PR TITLE
fix merge df out join

### DIFF
--- a/scripts/merge.py
+++ b/scripts/merge.py
@@ -202,7 +202,8 @@ def merge_data_sources(data_sources: list):
     for ds in data_sources:
         # Note that timestamps must have the same semantics, for example, start of kline (and not end of kline)
         # If different data sets have different semantics for timestamps, then data must be shifted accordingly
-        df_out = df_out.join(ds["df"])
+        df_out = df_out.join(ds["df"], rsuffix="_" + ds['column_prefix'])
+
 
     return df_out
 


### PR DESCRIPTION
I made a modification to the code by adding the rsuffix parameter to the join method. This parameter appends a specified suffix to the column names of the right DataFrame when there are overlapping column names during the join operation. This helps to disambiguate the columns and avoid the "ValueError: columns overlap but no suffix specified" error. The modified code ensures that the DataFrames are successfully joined even when they have overlapping column names.